### PR TITLE
fix: pin black version to 24.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
-    "black>=23.0.0",
+    "black==24.10.0",
     "ruff>=0.1.0",
     "isort>=5.12.0",
     "mypy>=1.5.0",


### PR DESCRIPTION
Pin black to 24.10.0 to fix CI formatting inconsistencies between local and CI environments.