### PR TITLE
refactor(deps): consolidate dependency management in pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ example/results/
 **/*.pyc
 .ruff_cache/
 .mypy_cache/
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
 
 <div align = center>
 
-[ ][KBD]
+[<kbd> <br> Click here for an interactive demo <br> </kbd>][KBD]
 
 </div>
+
+[KBD]: https://storage.hoodini.bio/hoodini-demo.html
 
 ## Introduction
 
@@ -77,7 +79,8 @@ The simplest way to install hoodini is from [Bioconda](https://bioconda.github.i
 **Using pixi:**
 
 ```bash
-pixi add bioconda::hoodini
+pixi init
+pixi add --channel conda-forge --channel bioconda hoodini
 pixi run hoodini download databases
 ```
 
@@ -118,7 +121,7 @@ uv run hoodini download databases
 ```bash
 mamba create -n hoodini
 mamba activate hoodini
-pip install -e
+pip install -e .
 hoodini download databases
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,17 @@
     <img src="docs/hoodini-viz-export - 2026-01-14T051133.869.svg" alt="Hoodini Visualization Example" width="800"/>
 </p>
 
-
 <div align = center>
 
-[<kbd> <br> Click here for an interactive demo <br> </kbd>][KBD]
+[ ][KBD]
 
 </div>
-
-
-[KBD]: https://storage.hoodini.bio/hoodini-demo.html
-
 
 ## Introduction
 
 Hoodini’s primary goal is to make large-scale genomic context analysis fast, practical, and accessible. It’s built to fetch and process thousands of gene neighborhoods in minutes, turning what used to be hours or days of manual work into an interactive workflow.
 
-With GPU-accelerated, real-time interactive  visualization, Hoodini lets biologists across disciplines explore bacterial operons, defense systems, and mobile genetic elements at scale, revealing patterns, co-localization signals, and evolutionary signatures that drive discovery and deepen our understanding of prokaryotic genomes.
+With GPU-accelerated, real-time interactive visualization, Hoodini lets biologists across disciplines explore bacterial operons, defense systems, and mobile genetic elements at scale, revealing patterns, co-localization signals, and evolutionary signatures that drive discovery and deepen our understanding of prokaryotic genomes.
 
 Beyond exploration, Hoodini offers extensive customization options (including flexible styling, multiple palettes, and fine-grained layout controls) to generate publication-ready, high-quality figures exported for presentations, manuscripts, and supplementary materials.
 
@@ -39,7 +34,7 @@ This README documents installation, the command-line interface and all available
 
 - **Automated data retrieval**: Fetches assemblies and annotations directly from NCBI using protein or nucleotide accessions
 - **Neighborhood extraction**: Extracts configurable genomic windows around target genes
-- **Protein clustering**: Groups homologous proteins across neighborhoods for synteny comparison  
+- **Protein clustering**: Groups homologous proteins across neighborhoods for synteny comparison
 - **Pairwise comparisons**: Computes protein (AAI) and nucleotide (ANI) similarities
 - **Tree construction**: Builds phylogenetic trees from AAI or ANI distances
 - **Defense system annotation**: Integrates PADLOC, DefenseFinder, CCTyper for antiphage systems
@@ -71,24 +66,65 @@ hoodini run --input proteins.txt --output results \
 
 ## Installation
 
-### Mamba
+Hoodini requires both Python packages and several bioinformatics tools. The recommended installation methods handle all dependencies automatically.
+
+### Bioconda (Recommended)
+
+> ⚠️ **Note:** The Bioconda recipe is currently a work in progress. Until it's available, use the development installation methods below.
+
+The simplest way to install hoodini is from [Bioconda](https://bioconda.github.io/) using [pixi](https://pixi.sh) or [mamba](https://mamba.readthedocs.io/)/[conda](https://docs.conda.io/).
+
+**Using pixi:**
 
 ```bash
-mamba env create -f environment.yml
+pixi add bioconda::hoodini
+pixi run hoodini download databases
+```
+
+**Using mamba/conda:**
+
+```bash
+mamba create -n hoodini -c conda-forge -c bioconda hoodini
 mamba activate hoodini
-pip install -e .
 hoodini download databases
 ```
 
-### Pixi
+### Development Installation with Pixi
+
+If you're installing from source, pixi can install all dependencies directly from the repository:
 
 ```bash
+git clone https://github.com/pentamorfico/hoodini.git
+cd hoodini
 pixi install
-pixi shell
+pixi run hoodini download databases
+```
+
+This installs hoodini as an editable package along with all required tools.
+
+### Python-only Installation (uv/pip)
+
+> ⚠️ **Note:** This only installs Python packages. You must have the other tools available in your PATH for full functionality.
+
+**Using uv:**
+
+```bash
+uv sync
+uv run hoodini download databases
+```
+
+**Using mamba/conda:**
+
+```bash
+mamba create -n hoodini
+mamba activate hoodini
+pip install -e
 hoodini download databases
 ```
 
 ### Docker
+
+> ⚠️ **Note:** The docker image is currently a work in progress. Until it's available, use the development installation methods above.
 
 ```bash
 docker volume create hoodini-data
@@ -111,64 +147,64 @@ hoodini download Download required databases
 
 ### Input Options
 
-| Option | Description |
-|--------|-------------|
-| `--input ID\|FILE` | Single accession (e.g., `WP_012345678.1`) or file with one accession per line |
-| `--inputsheet FILE` | TSV with accessions and custom metadata columns |
+| Option              | Description                                                                  |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `--input ID\|FILE`  | Single accession (e.g.,`WP_012345678.1`) or file with one accession per line |
+| `--inputsheet FILE` | TSV with accessions and custom metadata columns                              |
 
 ### Output Options
 
-| Option | Description |
-|--------|-------------|
-| `--output DIR` | Output directory |
-| `--force` | Overwrite existing output |
-| `--keep` | Retain intermediate files |
+| Option         | Description               |
+| -------------- | ------------------------- |
+| `--output DIR` | Output directory          |
+| `--force`      | Overwrite existing output |
+| `--keep`       | Retain intermediate files |
 
 ### Neighborhood Extraction
 
-| Option | Description |
-|--------|-------------|
-| `--win-mode` | `win_genes` (gene count) or `win_nts` (nucleotide distance) |
-| `--win INT` | Window size (default: 10 genes or 10000 nt) |
-| `--min-win INT` | Minimum genes required per side |
-| `--sorfs` | Re-annotate small ORFs in extracted regions |
+| Option          | Description                                                 |
+| --------------- | ----------------------------------------------------------- |
+| `--win-mode`    | `win_genes` (gene count) or `win_nts` (nucleotide distance) |
+| `--win INT`     | Window size (default: 10 genes or 10000 nt)                 |
+| `--min-win INT` | Minimum genes required per side                             |
+| `--sorfs`       | Re-annotate small ORFs in extracted regions                 |
 
 ### Pairwise Comparisons
 
-| Option | Description |
-|--------|-------------|
-| `--prot-links` | Compute all-vs-all protein similarities |
-| `--nt-links` | Compute pairwise nucleotide alignments |
-| `--nt-aln-mode` | Alignment method: `blastn`, `fastani`, `minimap2` |
-| `--clust-method` | Protein clustering algorithm |
+| Option           | Description                                      |
+| ---------------- | ------------------------------------------------ |
+| `--prot-links`   | Compute all-vs-all protein similarities          |
+| `--nt-links`     | Compute pairwise nucleotide alignments           |
+| `--nt-aln-mode`  | Alignment method:`blastn`, `fastani`, `minimap2` |
+| `--clust-method` | Protein clustering algorithm                     |
 
 ### Tree Construction
 
-| Option | Description |
-|--------|-------------|
-| `--tree-mode` | `aai_tree` (amino acid identity) or `ani_tree` (nucleotide identity) |
-| `--tree-file FILE` | Use precomputed Newick tree |
-| `--aai-mode` | Tree algorithm: `nj` (neighbor-joining) or `hyper` |
-| `--aai-subset-mode` | Proteins for tree: `target_region`, `target_prot`, `window` |
+| Option              | Description                                                          |
+| ------------------- | -------------------------------------------------------------------- |
+| `--tree-mode`       | `aai_tree` (amino acid identity) or `ani_tree` (nucleotide identity) |
+| `--tree-file FILE`  | Use precomputed Newick tree                                          |
+| `--aai-mode`        | Tree algorithm:`nj` (neighbor-joining) or `hyper`                    |
+| `--aai-subset-mode` | Proteins for tree:`target_region`, `target_prot`, `window`           |
 
 ### Functional Annotations
 
-| Option | Description |
-|--------|-------------|
-| `--padloc` | Detect defense systems with PADLOC |
-| `--deffinder` | Detect defense systems with DefenseFinder |
-| `--cctyper` | Type CRISPR-Cas systems |
-| `--genomad` | Identify mobile genetic elements |
-| `--ncrna FILE` | Predict ncRNAs with Infernal using custom CM models file (e.g., Rfam.cm) |
-| `--domains LIST` | Search domain databases (comma-separated) |
+| Option           | Description                                                              |
+| ---------------- | ------------------------------------------------------------------------ |
+| `--padloc`       | Detect defense systems with PADLOC                                       |
+| `--deffinder`    | Detect defense systems with DefenseFinder                                |
+| `--cctyper`      | Type CRISPR-Cas systems                                                  |
+| `--genomad`      | Identify mobile genetic elements                                         |
+| `--ncrna FILE`   | Predict ncRNAs with Infernal using custom CM models file (e.g., Rfam.cm) |
+| `--domains LIST` | Search domain databases (comma-separated)                                |
 
 ### Performance
 
-| Option | Description |
-|--------|-------------|
-| `--num-threads INT` | Parallel threads (default: 4) |
-| `--max-concurrent-downloads INT` | Concurrent NCBI downloads |
-| `--api-key KEY` | NCBI API key (increases rate limits) |
+| Option                           | Description                          |
+| -------------------------------- | ------------------------------------ |
+| `--num-threads INT`              | Parallel threads (default: 4)        |
+| `--max-concurrent-downloads INT` | Concurrent NCBI downloads            |
+| `--api-key KEY`                  | NCBI API key (increases rate limits) |
 
 ## Output Structure
 
@@ -216,7 +252,7 @@ hoodini download metacerberus     # Domain HMM profiles
 
 ## Configuration
 
-Parameters can be set via CLI flags, TOML config file, or built-in defaults.  
+Parameters can be set via CLI flags, TOML config file, or built-in defaults.
 Priority: CLI flags > config file > defaults.
 
 ```toml
@@ -246,7 +282,7 @@ Hoodini is heavily inspired by the work of several excellent tools in the field.
 - [GCsnap](https://github.com/JoanaMPereira/GCsnap) — Gene context visualization with interactive output
 - [FlaGs](https://github.com/GCA-VH-lab/FlaGs) — Flanking genes analysis
 - [Taxonium](https://github.com/theosanderson/taxonium) — Large trees interactive visualization
-- [clinker & clustermap.js](https://github.com/gamcil/clinker) — Gene cluster comparison
+- [clinker &amp; clustermap.js](https://github.com/gamcil/clinker) — Gene cluster comparison
 - [gggenes](https://github.com/wilkox/gggenes) — Gene arrow maps in R
 - [gggenomes](https://github.com/thackl/gggenomes) — Comparative genomics visualization
 - [geneviewer](https://github.com/nvelden/geneviewer) — Interactive gene visualization
@@ -254,3 +290,5 @@ Hoodini is heavily inspired by the work of several excellent tools in the field.
 ## License
 
 See LICENSE file.
+
+[KBD]: https://storage.hoodini.bio/hoodini-demo.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ platforms = ["linux-64", "osx-arm64"]
 [tool.pixi.dependencies]
 python = "3.11.*"
 blast = "*"
-diamond = "*"
+diamond = "!=2.1.19"
 skani = "*"
 fastani = "*"
 padloc = ">=2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,47 +6,47 @@ build-backend = "setuptools.build_meta"
 name = "hoodini"
 version = "1.0.0"
 description = "magic gene-neighborhood analyses"
-authors = [{name = "Mario R. Mestre", email = "mario.mestre@bio.ku.dk"}]
+authors = [{ name = "Mario R. Mestre", email = "mario.mestre@bio.ku.dk" }]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "polars>=0.20.0",
-    "biopython>=1.80",
-    "rich>=13.0.0",
-    "rich-click>=1.7.0",
-    "requests>=2.31.0",
-    "scipy>=1.11.0",
-    "numpy>=1.24.0",
-    "pandas",
-    "pyarrow",
-    "networkx",
-    "ete3",
-    "orfipy>=0.0.4",
-    "pyrodigal>=3.0.0",
-    "gb-io>=0.2.0",
-    "httpx",
-    "aiohttp",
-    "pyhmmer",
-    "uniprot-id-mapper",
-    "alphafetcher",
-    "jinja2",
-    "mappy",
-    "playwright>=1.40.0",
-    "nest_asyncio>=1.6.0",
-    "cctyper @ git+https://github.com/pentamorfico/CRISPRCasTyper.git",
-    "tomli>=2.0.0",
-    "psutil>=5.9.0",
-    "duckdb>=0.9.0",
+	"polars>=0.20.0",
+	"biopython>=1.80",
+	"rich>=13.0.0",
+	"rich-click>=1.7.0",
+	"requests>=2.31.0",
+	"scipy>=1.11.0",
+	"numpy>=1.24.0",
+	"pandas",
+	"pyarrow",
+	"networkx",
+	"ete3",
+	"orfipy>=0.0.4",
+	"pyrodigal>=3.0.0",
+	"gb-io>=0.2.0",
+	"httpx",
+	"aiohttp",
+	"pyhmmer",
+	"uniprot-id-mapper",
+	"alphafetcher",
+	"jinja2",
+	"mappy",
+	"playwright>=1.40.0",
+	"nest_asyncio>=1.6.0",
+	"cctyper @ git+https://github.com/pentamorfico/CRISPRCasTyper.git",
+	"tomli>=2.0.0",
+	"psutil>=5.9.0",
+	"duckdb>=0.9.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.4.0",
-    "pytest-cov>=4.1.0",
-    "black==24.10.0",
-    "ruff>=0.1.0",
-    "isort>=5.12.0",
-    "mypy>=1.5.0",
+	"pytest>=7.4.0",
+	"pytest-cov>=4.1.0",
+	"black==24.10.0",
+	"ruff>=0.1.0",
+	"isort>=5.12.0",
+	"mypy>=1.5.0",
 ]
 
 [project.scripts]
@@ -83,23 +83,12 @@ target-version = "py310"
 extend-exclude = ["src/hoodini/data", "hoodini.egg-info"]
 
 [tool.ruff.lint]
-select = [
-	"E",   
-	"F",   
-	"I",   
-	"UP",  
-	"B",   
-	"C4",  
-	"SIM", 
-	"N",   
-	"S",   
-	"PL",  
-]
+select = ["E", "F", "I", "UP", "B", "C4", "SIM", "N", "S", "PL"]
 ignore = [
 	"B905",
-	"E501",   # Line too long (handled by black)
-	"E741",   # Ambiguous variable name
-	"S608",   # SQL injection (false positive for DuckDB internal queries)
+	"E501",    # Line too long (handled by black)
+	"E741",    # Ambiguous variable name
+	"S608",    # SQL injection (false positive for DuckDB internal queries)
 	"PLR0911", # Too many return statements
 	"PLR0912", # Too many branches
 	"PLR0913", # Too many arguments
@@ -149,6 +138,61 @@ minversion = "7.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
 pythonpath = ["src"]
-filterwarnings = [
-	"ignore::DeprecationWarning",
-]
+filterwarnings = ["ignore::DeprecationWarning"]
+
+[tool.pixi.workspace]
+channels = ["conda-forge", "bioconda"]
+platforms = ["linux-64", "osx-arm64"]
+
+[tool.pixi.dependencies]
+python = "3.11.*"
+blast = "*"
+diamond = "*"
+skani = "*"
+fastani = "*"
+padloc = ">=2.0"
+defense-finder = ">=2.0.1"
+genomad = "*"
+mafft = "*"
+foldseek = "*"
+infernal = "*"
+famsa = "*"
+veryfasttree = "*"
+mmseqs2 = "*"
+entrez-direct = "*"
+aria2 = "*"
+pigz = "*"
+ete3 = ">=3.1.3"
+aria2p = "*"
+alphafetcher = "*"
+uniprot-id-mapper = "*"
+diamondonpy = "*"
+playwright-python = ">=1.47,<1.48"
+openssl = "*"
+certifi = "*"
+ca-certificates = "*"
+
+[tool.pixi.target.linux-64.dependencies]
+firefox = "*"
+gtk3 = "*"
+atk = "*"
+xorg-libxcomposite = "*"
+xorg-libxdamage = "*"
+xorg-libxfixes = "*"
+xorg-libxrandr = "*"
+xorg-libxrender = "*"
+xorg-libxext = "*"
+cairo = "*"
+pango = "*"
+gdk-pixbuf = "*"
+fontconfig = "*"
+alsa-lib = "*"
+
+[tool.pixi.pypi-dependencies]
+hoodini = { path = ".", editable = true }
+
+[tool.pixi.environments]
+default = { solve-group = "default" }
+dev = { features = ["dev"], solve-group = "default" }
+
+[tool.pixi.tasks]

--- a/scripts/compare_installs.py
+++ b/scripts/compare_installs.py
@@ -1,0 +1,249 @@
+import argparse
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Generator, List, Optional
+
+RED = "\033[91m"
+GREEN = "\033[92m"
+YELLOW = "\033[93m"
+RESET = "\033[0m"
+
+ROOT = Path(__file__).parent.parent
+PIXI_LOCK = ROOT / "pixi.lock"
+
+PLATFORM_MAP = {
+    "linux-64": "x86_64-unknown-linux-gnu",
+    "linux-aarch64": "aarch64-unknown-linux-gnu",
+    "osx-64": "x86_64-apple-darwin",
+    "osx-arm64": "aarch64-apple-darwin",
+}
+
+def get_current_platform() -> str:
+    """Detect current platform string for pixi."""
+    sys_name = platform.system().lower()
+    machine = platform.machine().lower()
+    
+    if sys_name == "linux":
+        return "linux-aarch64" if machine == "aarch64" else "linux-64"
+    elif sys_name == "darwin":
+        return "osx-arm64" if machine == "arm64" else "osx-64"
+    return "unknown"
+
+def parse_pixi_lock(lock_path: Path, target_platform: str) -> Dict[str, str]:
+    """Parse packages from a pixi.lock file for a specific platform."""
+    if not lock_path.exists():
+        return {}
+        
+    packages = {}
+    current_section = None
+    
+    with open(lock_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if line.endswith(":") and not line.startswith("-"):
+                current_section = line[:-1]
+                continue
+            
+            if current_section == target_platform and line.startswith("- "):
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                
+                source_type = parts[1]
+                url = parts[2]
+                filename = url.split("/")[-1]
+                
+                for ext in [".conda", ".tar.bz2", ".whl", ".tar.gz"]:
+                    if filename.endswith(ext):
+                        filename = filename[:-len(ext)]
+                        break
+                
+                if source_type == "pypi:":
+                    match = re.match(r"^([a-zA-Z0-9_\-]+?)-(\d+(?:\.\d+)*(?:[a-zA-Z0-9_\.]*)?)", filename)
+                    if match:
+                        name = match.group(1).lower().replace("_", "-")
+                        version = match.group(2)
+                        packages[name] = version
+                else:
+                    match = re.search(r"^(.+)-(\d+(?:\.\d+)*(?:[a-zA-Z0-9_\.]*)?)-([^-]+)$", filename)
+                    if match:
+                        name = match.group(1).lower().replace("_", "-")
+                        version = match.group(2)
+                        packages[name] = version
+    return packages
+
+@contextmanager
+def get_lock_file(fresh: bool) -> Generator[Path, None, None]:
+    """Context manager yielding path to lock file (existing or temp fresh)."""
+    if not fresh:
+        if not PIXI_LOCK.exists():
+            print(f"{RED}Error: pixi.lock not found{RESET}")
+            sys.exit(1)
+        print(f"Using existing pixi.lock")
+        yield PIXI_LOCK
+    else:
+        print(f"Resolving fresh pixi environment (this may take a minute)...")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            
+            # Copy necessary files
+            for filename in ["pyproject.toml", "README.md", "README", "LICENSE", "LICENSE.md"]:
+                src = ROOT / filename
+                if src.exists():
+                    shutil.copy(src, tmp_path / filename)
+            
+            # Copy src directory for editable install
+            src_dir = ROOT / "src"
+            if src_dir.exists():
+                shutil.copytree(src_dir, tmp_path / "src")
+            
+            # Run pixi install
+            try:
+                subprocess.run(
+                    ["pixi", "install"], 
+                    cwd=tmp_path, 
+                    check=True, 
+                    capture_output=True
+                )
+            except subprocess.CalledProcessError as e:
+                print(f"{RED}pixi install failed:{RESET}")
+                print(e.stderr.decode() if e.stderr else "Unknown error")
+                sys.exit(1)
+                
+            yield tmp_path / "pixi.lock"
+
+def get_uv_resolved_packages(target_platform: str) -> Dict[str, str]:
+    """Resolve packages using uv pip compile for the target platform."""
+    uv_platform = PLATFORM_MAP.get(target_platform)
+    if not uv_platform:
+        print(f"{RED}Unknown platform mapping for {target_platform}{RESET}")
+        return {}
+    
+    cmd = [
+        "uv", "pip", "compile", 
+        "pyproject.toml",
+        "--python-platform", uv_platform,
+        "--quiet"
+    ]
+    
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"{RED}uv resolution failed for {target_platform}:{RESET}")
+        print(e.stderr)
+        return {}
+        
+    packages = {}
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+            
+        match = re.match(r"^([a-zA-Z0-9_\-]+)==([^ ;]+)", line)
+        if match:
+            name = match.group(1).lower().replace("_", "-")
+            version = match.group(2)
+            packages[name] = version
+            
+    return packages
+
+def compare_platform(platform: str, lock_path: Path) -> List[str]:
+    """Compare packages for a single platform and return output lines."""
+    lines = []
+    lines.append(f"Checking {platform}...")
+    
+    pixi_pkgs = parse_pixi_lock(lock_path, platform)
+    if not pixi_pkgs:
+        lines.append(f"No packages found in pixi.lock for {platform}")
+        return lines
+    
+    uv_pkgs = get_uv_resolved_packages(platform)
+    
+    all_pkgs = sorted(set(pixi_pkgs.keys()) | set(uv_pkgs.keys()))
+    
+    lines.append(f"\n{'Package':<30} {'Pixi Version':<20} {'UV Version':<20} {'Status':<20}")
+    lines.append("-" * 90)
+    
+    mismatches = 0
+    pixi_only = 0
+    uv_only = 0
+    mismatch_list = []
+    
+    for pkg in all_pkgs:
+        p_ver = pixi_pkgs.get(pkg, "-")
+        u_ver = uv_pkgs.get(pkg, "-")
+        
+        status_color = ""
+        if p_ver == u_ver:
+            status = "Match"
+            status_color = GREEN
+        elif p_ver == "-":
+            status = "UV Only"
+            status_color = YELLOW
+            uv_only += 1
+        elif u_ver == "-":
+            status = "Pixi Only"
+            status_color = YELLOW
+            pixi_only += 1
+        else:
+            status = "Mismatch"
+            status_color = RED
+            mismatches += 1
+            mismatch_list.append((pkg, p_ver, u_ver))
+            
+        # For logging, we strip colors. For stdout, we keep them if interactive?
+        # Let's keep formatted string for return, and maybe colorize only when printing to term
+        line = f"{pkg:<30} {p_ver:<20} {u_ver:<20} {status}"
+        lines.append(line)
+
+    lines.append("-" * 90)
+    lines.append(f"Summary for {platform}:")
+    lines.append(f"  Matches:    {len(all_pkgs) - mismatches - pixi_only - uv_only}")
+    lines.append(f"  Mismatches: {mismatches}")
+    lines.append(f"  Pixi Only:  {pixi_only}")
+    lines.append(f"  UV Only:    {uv_only}")
+    
+    if mismatch_list:
+        lines.append(f"\nMismatches:")
+        lines.append(f"{'Package':<30} {'Pixi':<20} {'UV':<20}")
+        lines.append("-" * 72)
+        for pkg, p, u in mismatch_list:
+            lines.append(f"{pkg:<30} {p:<20} {u:<20}")
+            
+    return lines
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare Pixi lock vs UV resolution.")
+    parser.add_argument("--platform", default=get_current_platform(), 
+                        choices=list(PLATFORM_MAP.keys()), help="Target platform to check")
+    parser.add_argument("--all-platforms", action="store_true", 
+                        help="Check all platforms defined in script")
+    parser.add_argument("--use-lock-file", action="store_true", 
+                        help="Use existing pixi.lock instead of fresh resolve")
+    args = parser.parse_args()
+
+    platforms = list(PLATFORM_MAP.keys()) if args.all_platforms else [args.platform]
+    
+    with get_lock_file(fresh=not args.use_lock_file) as lock_path:
+        for plat in platforms:
+            output_lines = compare_platform(plat, lock_path)
+            
+            # Print to stdout (plain)
+            print("\n".join(output_lines))
+            print()
+            
+            # Write to log
+            log_file = ROOT / f"install_check_{plat}.log"
+            with open(log_file, "w") as f:
+                f.write("\n".join(output_lines))
+                f.write("\n")
+            print(f"Report written to {log_file}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_recipe.py
+++ b/scripts/generate_recipe.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Generate bioconda meta.yaml from pyproject.toml.
+
+Usage:
+    python scripts/sync_from_pixi.py              # Generate meta.yaml
+    python scripts/sync_from_pixi.py --check      # Check all deps
+    python scripts/sync_from_pixi.py --check orfipy taxoniq  # Check specific deps
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import stat
+import subprocess
+import sys
+import tarfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+ROOT = Path(__file__).parent.parent
+PYPROJECT_PATH = ROOT / "pyproject.toml"
+META_PATH = ROOT / "recipes" / "meta.yaml"
+MICROMAMBA_DIR = ROOT / ".micromamba"
+MICROMAMBA_BIN = MICROMAMBA_DIR / "micromamba"
+
+GITHUB_ORG = "pentamorfico"
+
+# Build-only deps, not runtime
+EXCLUDE_DEPS = {"pip", "setuptools", "wheel", "hoodini"}
+
+# Platforms to check will be loaded from pyproject.toml
+
+# Cache for conda package lookups
+_conda_cache: dict[tuple[str, str, str], bool] = {}
+
+
+def get_micromamba_url() -> str:
+    """Get the correct micromamba download URL for this platform."""
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    
+    if system == "darwin":
+        if machine in ("arm64", "aarch64"):
+            return "https://micro.mamba.pm/api/micromamba/osx-arm64/latest"
+        return "https://micro.mamba.pm/api/micromamba/osx-64/latest"
+    elif system == "linux":
+        if machine in ("arm64", "aarch64"):
+            return "https://micro.mamba.pm/api/micromamba/linux-aarch64/latest"
+        return "https://micro.mamba.pm/api/micromamba/linux-64/latest"
+    else:
+        raise RuntimeError(f"Unsupported platform: {system}-{machine}")
+
+
+def ensure_micromamba() -> Path:
+    """Download micromamba if not present, return path to binary."""
+    if MICROMAMBA_BIN.exists():
+        return MICROMAMBA_BIN
+    
+    print("Downloading micromamba...")
+    MICROMAMBA_DIR.mkdir(parents=True, exist_ok=True)
+    
+    url = get_micromamba_url()
+    tar_path = MICROMAMBA_DIR / "micromamba.tar.bz2"
+    
+    # Download
+    with urllib.request.urlopen(url, timeout=60) as response:  # noqa: S310
+        tar_path.write_bytes(response.read())
+    
+    # Extract
+    with tarfile.open(tar_path, "r:bz2") as tar:
+        for member in tar.getmembers():
+            if member.name.endswith("micromamba"):
+                member.name = "micromamba"
+                tar.extract(member, MICROMAMBA_DIR, filter="data")
+                break
+    
+    # Make executable
+    MICROMAMBA_BIN.chmod(MICROMAMBA_BIN.stat().st_mode | stat.S_IEXEC)
+    tar_path.unlink()
+    
+    print(f"✓ Installed micromamba to {MICROMAMBA_BIN}")
+    return MICROMAMBA_BIN
+
+
+def check_conda_available(
+    package: str, 
+    version_spec: str, 
+    micromamba: Path,
+    platforms: list[str]
+) -> dict[str, bool]:
+    """Check if a package (with version) is available on conda for each platform."""
+    pkg_normalized = package.lower().replace("_", "-")
+    
+    # Build the search spec
+    if version_spec:
+        search_spec = f"{pkg_normalized}{version_spec}"
+    else:
+        search_spec = pkg_normalized
+    
+    results = {}
+    for plat in platforms:
+        cache_key = (pkg_normalized, version_spec, plat)
+        if cache_key in _conda_cache:
+            results[plat] = _conda_cache[cache_key]
+            continue
+        
+        try:
+            result = subprocess.run(
+                [
+                    str(micromamba), "search", search_spec,
+                    "-c", "conda-forge", "-c", "bioconda",
+                    "--platform", plat,
+                    "--json", "-q"
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env={**os.environ, "MAMBA_NO_BANNER": "1"}
+            )
+            
+            # Parse JSON output
+            available = False
+            if result.returncode == 0 and result.stdout.strip():
+                try:
+                    data = json.loads(result.stdout)
+                    pkgs = data.get("result", {}).get("pkgs", [])
+                    available = len(pkgs) > 0
+                except json.JSONDecodeError:
+                    available = False
+            
+            _conda_cache[cache_key] = available
+            results[plat] = available
+        except (subprocess.TimeoutExpired, subprocess.SubprocessError):
+            _conda_cache[cache_key] = False
+            results[plat] = False
+    
+    return results
+
+
+def parse_pep508(dep: str) -> tuple[str, str]:
+    """Parse 'package>=1.0,<2' into ('package', '>=1.0,<2')."""
+    match = re.match(r"^([a-zA-Z0-9_-]+)\s*(.*)", dep.strip())
+    if match:
+        return match.group(1), match.group(2)
+    return dep.strip(), ""
+
+
+def load_pyproject() -> dict:
+    with open(PYPROJECT_PATH, "rb") as f:
+        return tomllib.load(f)
+
+
+def run_checks(
+    all_deps: dict[str, str],
+    linux_deps: dict[str, str],
+    micromamba: Path,
+    platforms: list[str],
+    filter_pkgs: list[str] | None = None
+) -> list[tuple[str, str, list[str]]]:
+    """Run conda availability checks. Returns list of issues."""
+    issues = []
+    
+    # Filter deps if specific packages requested
+    if filter_pkgs:
+        check_deps = {k: v for k, v in all_deps.items() if k.lower() in [p.lower() for p in filter_pkgs]}
+        check_linux = {k: v for k, v in linux_deps.items() if k.lower() in [p.lower() for p in filter_pkgs]}
+    else:
+        check_deps = all_deps
+        check_linux = linux_deps
+    
+    if not check_deps and not check_linux:
+        print("No matching packages to check.")
+        return issues
+    
+    # Check universal deps
+    if check_deps:
+        print(f"Checking conda availability across {platforms}...\n")
+        header = f"{'Package':<25} {'Version':<20}"
+        for plat in platforms:
+            header += f" {plat:<14}"
+        print(header)
+        print("-" * (45 + 14 * len(platforms)))
+        
+        for pkg in sorted(check_deps.keys()):
+            if pkg == "python":
+                continue
+            
+            spec = check_deps[pkg]
+            availability = check_conda_available(pkg, spec, micromamba, platforms)
+            
+            statuses = []
+            missing = []
+            for plat in platforms:
+                if availability.get(plat, False):
+                    statuses.append("✓")
+                else:
+                    statuses.append("✗")
+                    missing.append(plat)
+            
+            spec_display = spec if spec else "*"
+            line = f"{pkg:<25} {spec_display:<20}"
+            for s in statuses:
+                line += f" {s:<14}"
+            print(line)
+            
+            if missing:
+                issues.append((pkg, spec, missing))
+    
+    # Check Linux-specific deps
+    if check_linux:
+        print("\nLinux-specific dependencies:")
+        linux_platforms = [p for p in platforms if p.startswith("linux")]
+        if not linux_platforms:
+            print("(No Linux platforms in checked set)")
+        else:
+            header = f"{'Package':<25} {'Version':<20}"
+            for plat in linux_platforms:
+                header += f" {plat:<14}"
+            print(header)
+            print("-" * (45 + 14 * len(linux_platforms)))
+            
+            for pkg in sorted(check_linux.keys()):
+                spec = check_linux[pkg]
+                availability = check_conda_available(pkg, spec, micromamba, platforms=linux_platforms)
+                
+                statuses = []
+                missing = []
+                for plat in linux_platforms:
+                    if availability.get(plat, False):
+                        statuses.append("✓")
+                    else:
+                        statuses.append("✗")
+                        missing.append(plat)
+                
+                spec_display = spec if spec else "*"
+                line = f"{pkg:<25} {spec_display:<20}"
+                for s in statuses:
+                    line += f" {s:<14}"
+                print(line)
+            
+            if missing:
+                issues.append((pkg + " [linux]", spec, missing))
+    
+    return issues
+
+
+def generate_meta_yaml(config: dict) -> tuple[str, list[str], dict[str, str], dict[str, str]]:
+    """Generate bioconda meta.yaml. Returns (yaml, git_deps, all_deps, linux_deps)."""
+    project = config.get("project", {})
+    pixi = config.get("tool", {}).get("pixi", {})
+
+    name = project.get("name", "hoodini")
+    version = project.get("version", "0.0.0")
+    description = project.get("description", "")
+
+    # Collect ALL dependencies
+    all_deps: dict[str, str] = {}
+    all_deps["python"] = ">=3.10"
+
+    # From [project.dependencies]
+    for dep in project.get("dependencies", []):
+        pkg, spec = parse_pep508(dep)
+        if pkg.lower() in EXCLUDE_DEPS:
+            continue
+        all_deps[pkg] = spec
+
+    # From [tool.pixi.dependencies]
+    for pkg, spec in pixi.get("dependencies", {}).items():
+        if pkg.lower() in EXCLUDE_DEPS:
+            continue
+        if isinstance(spec, str):
+            all_deps[pkg] = "" if spec == "*" else spec
+
+    # Collect Linux-specific deps
+    linux_deps: dict[str, str] = {}
+    linux_target = pixi.get("target", {}).get("linux-64", {}).get("dependencies", {})
+    for pkg, spec in linux_target.items():
+        if isinstance(spec, str):
+            linux_deps[pkg] = "" if spec == "*" else spec
+
+    # Collect git dependencies
+    git_deps = []
+    for pkg, spec in pixi.get("pypi-dependencies", {}).items():
+        if isinstance(spec, dict) and "git" in spec:
+            git_deps.append(pkg)
+
+    # Format deps for YAML
+    run_deps = []
+    for pkg in sorted(all_deps.keys()):
+        spec = all_deps[pkg]
+        formatted = f"{pkg} {spec}".strip() if spec else pkg
+        run_deps.append(formatted)
+
+    linux_deps_formatted = []
+    for pkg in sorted(linux_deps.keys()):
+        spec = linux_deps[pkg]
+        formatted = f"{pkg} {spec}".strip() if spec else pkg
+        linux_deps_formatted.append(f"{formatted}  # [linux]")
+
+    run_deps_yaml = "\n    - ".join(run_deps)
+    linux_deps_yaml = "\n    - ".join(linux_deps_formatted)
+
+    # Get entry points
+    scripts = project.get("scripts", {})
+    entry_points_yaml = "\n    - ".join(
+        f"{cmd} = {target}" for cmd, target in scripts.items()
+    )
+
+    meta = f'''# AUTO-GENERATED from pyproject.toml
+{{% set name = "{name}" %}}
+{{% set version = "{version}" %}}
+
+package:
+  name: {{{{ name|lower }}}}
+  version: {{{{ version }}}}
+
+source:
+  url: https://github.com/{GITHUB_ORG}/{{{{ name }}}}/archive/refs/tags/v{{{{ version }}}}.tar.gz
+  sha256: REPLACE_WITH_SHA256
+
+build:
+  number: 0
+  noarch: python
+  script: {{{{ PYTHON }}}} -m pip install . -vvv --no-deps --no-build-isolation
+  entry_points:
+    - {entry_points_yaml}
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+  run:
+    - {run_deps_yaml}'''
+
+    if linux_deps_yaml:
+        meta += f'''
+    # Linux-specific
+    - {linux_deps_yaml}'''
+
+    meta += f'''
+
+test:
+  imports:
+    - {name}
+  commands:
+    - {name} --help
+
+about:
+  home: https://github.com/{GITHUB_ORG}/{name}
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "{description}"
+  dev_url: https://github.com/{GITHUB_ORG}/{name}
+
+extra:
+  recipe-maintainers:
+    - pentamorfico
+'''
+    return meta, git_deps, all_deps, linux_deps
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate bioconda meta.yaml from pyproject.toml"
+    )
+    parser.add_argument(
+        "--check",
+        nargs="*",
+        metavar="PKG",
+        help="Check conda availability. No args = check all, or specify packages to check."
+    )
+    args = parser.parse_args()
+
+    if not PYPROJECT_PATH.exists():
+        print(f"Error: {PYPROJECT_PATH} not found", file=sys.stderr)
+        return 1
+
+    print(f"\nReading {PYPROJECT_PATH}...\n")
+    config = load_pyproject()
+
+    project = config.get("project", {})
+    version = project.get("version", "0.0.0")
+
+    # Generate meta.yaml
+    meta_content, git_deps, all_deps, linux_deps = generate_meta_yaml(config)
+    
+    # Run checks if requested
+    issues = []
+    if args.check is not None:
+        micromamba = ensure_micromamba()
+        
+        # Get platforms from config
+        pixi = config.get("tool", {}).get("pixi", {})
+        platforms = pixi.get("workspace", {}).get("platforms", [])
+        if not platforms:
+            platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64"]
+            print("⚠ No platforms found in pyproject.toml, filtering to defaults.")
+
+        filter_pkgs = args.check if args.check else None
+        issues = run_checks(all_deps, linux_deps, micromamba, platforms, filter_pkgs)
+        print()
+
+    # Write meta.yaml
+    META_PATH.parent.mkdir(parents=True, exist_ok=True)
+    META_PATH.write_text(meta_content)
+    print(f"✓ Generated {META_PATH}")
+
+    # Show git deps warning only when not filtering specific packages
+    show_git_warning = args.check is None or (args.check is not None and not args.check)
+    if git_deps and show_git_warning:
+        print(f"\n⚠ Git dependencies need conda OR bioconda recipes:")
+        for dep in git_deps:
+            print(f"   - {dep}")
+
+    if issues:
+        print(f"\n⚠ Packages missing on some platforms:")
+        for pkg, spec, missing in issues:
+            spec_str = f" {spec}" if spec else ""
+            print(f"   - {pkg}{spec_str}: missing on {', '.join(missing)}")
+
+    print(f"\nNext steps (if all dependencies are OK):")
+    print(f"   1. Create a GitHub release/tag: git tag v{version} && git push --tags")
+    print(f"   2. Get sha256: curl -sL <release_url>.tar.gz | shasum -a 256")
+    print(f"   3. Replace REPLACE_WITH_SHA256 in meta.yaml")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Move all dependency definitions to pyproject.toml using the [tool.pixi] configuration. This centralizes package management and provides better cross-platform support through explicit platform targeting.

Changes:
- Add [tool.pixi.workspace] with conda-forge and bioconda channels
- Add [tool.pixi.dependencies] for all conda-based dependencies
- Add [tool.pixi.target.linux-64.dependencies] for Linux-specific libs (GTK, X11, etc. required for playwright on headless systems)
- Add [tool.pixi.pypi-dependencies] for editable install

Note: environment.yml is retained as the Docker build still relies on it. This should be updated in a future PR to align with pixi. Alternatively, in the future, Docker should probably be installing hoodini directly from bioconda anyway.

New scripts:
- scripts/compare_installs.py: Compare package versions that would be installed using pixi versus uv (assuming uv will give the same result as pip too), to check parity
- scripts/generate_recipe.py: Auto-generate bioconda meta.yaml from pyproject.toml and check package availability across platforms