### PR TITLE
Fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 	"tomli>=2.0.0",
 	"psutil>=5.9.0",
 	"duckdb>=0.9.0",
+	"uniprot-id-mapper>=0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -197,6 +198,7 @@ alsa-lib = "*"
 
 [tool.pixi.pypi-dependencies]
 hoodini = { path = ".", editable = true }
+uniprot-id-mapper = "*"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,6 @@ alsa-lib = "*"
 
 [tool.pixi.pypi-dependencies]
 hoodini = { path = ".", editable = true }
-uniprot-id-mapper = "*"
 
 [tool.pixi.environments]
 default = { solve-group = "default" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 	"gb-io>=0.2.0",
 	"httpx",
 	"aiohttp",
-	"pyhmmer",
+	"pyhmmer<0.12",
 	"alphafetcher",
 	"jinja2",
 	"mappy",
@@ -142,10 +142,10 @@ testpaths = ["tests"]
 pythonpath = ["src"]
 filterwarnings = ["ignore::DeprecationWarning"]
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests as integration tests requiring network",
-    "unit: marks tests as fast unit tests",
-    "requires_db: marks tests requiring external databases (PADLOC, DefenseFinder)",
+	"slow: marks tests as slow (deselect with '-m \"not slow\"')",
+	"integration: marks tests as integration tests requiring network",
+	"unit: marks tests as fast unit tests",
+	"requires_db: marks tests requiring external databases (PADLOC, DefenseFinder)",
 ]
 
 [tool.pixi.workspace]
@@ -155,7 +155,7 @@ platforms = ["linux-64", "osx-arm64"]
 [tool.pixi.dependencies]
 python = "3.11.*"
 blast = "*"
-diamond = "!=2.1.19"
+diamond = ">=2.1.22"
 skani = "*"
 fastani = "*"
 padloc = ">=2.0"

--- a/src/hoodini/download/contig_lengths.py
+++ b/src/hoodini/download/contig_lengths.py
@@ -130,7 +130,8 @@ def get_missing_contigs_from_summary(
         if all_parquet_files:
             # Query existing contig assemblies and do anti-join
             contig_glob = str(CONTIG_LENGTHS_DIR / "*.parquet")
-            missing_df = con.execute(f"""
+            missing_df = con.execute(
+                f"""
                 WITH summary AS ({summary_query}),
                 existing AS (
                     SELECT DISTINCT CAST(assemblyAccession AS VARCHAR) as assembly_accession
@@ -140,7 +141,8 @@ def get_missing_contigs_from_summary(
                 FROM summary s
                 LEFT JOIN existing e ON s.assembly_accession = e.assembly_accession
                 WHERE e.assembly_accession IS NULL
-            """).pl()
+            """
+            ).pl()
         else:
             console.log("No existing contig_lengths found, will download all")
             missing_df = con.execute(summary_query).pl()
@@ -387,14 +389,16 @@ def download_contig_lengths(
         con = duckdb.connect(":memory:")
         con.execute('SET memory_limit = "4GB"')
         groups_str = ", ".join(f"'{g}'" for g in DEFAULT_GROUPS)
-        candidate_df = con.execute(f"""
+        candidate_df = con.execute(
+            f"""
             SELECT DISTINCT CAST(assembly_accession AS VARCHAR) as assembly_accession
             FROM read_parquet('{str(ASSEMBLY_SUMMARY)}')
             WHERE "group" IN ({groups_str})
               AND ftp_path IS NOT NULL
               AND TRIM(ftp_path) != ''
               AND LOWER(ftp_path) != 'na'
-        """).pl()
+        """
+        ).pl()
         con.close()
         candidate_ids = candidate_df["assembly_accession"].to_list()
 
@@ -425,10 +429,12 @@ def download_contig_lengths(
                 con.execute('SET memory_limit = "4GB"')
 
                 # Check if seq_rel_date column exists
-                schema_result = con.execute(f"""
+                schema_result = con.execute(
+                    f"""
                     SELECT name FROM parquet_schema('{str(ASSEMBLY_SUMMARY)}')
                     WHERE name = 'seq_rel_date'
-                """).fetchone()
+                """
+                ).fetchone()
 
                 if schema_result:
                     remote_date = remote_last_mod.date()
@@ -437,7 +443,8 @@ def download_contig_lengths(
                     con.register("missing_asm", missing_df)
 
                     # Filter: keep if date is null OR date > remote_date
-                    missing_df = con.execute(f"""
+                    missing_df = con.execute(
+                        f"""
                         SELECT DISTINCT m.assembly_accession
                         FROM missing_asm m
                         LEFT JOIN (
@@ -447,7 +454,8 @@ def download_contig_lengths(
                             FROM read_parquet('{str(ASSEMBLY_SUMMARY)}')
                         ) a ON m.assembly_accession = a.assembly_accession
                         WHERE a.seq_rel_date IS NULL OR a.seq_rel_date > '{remote_date_str}'
-                    """).pl()
+                    """
+                    ).pl()
 
                     console.log(
                         f"Filtered by remote date ({remote_date}): {missing_df.height:,} assemblies remain"

--- a/src/hoodini/extra_tools/emapper.py
+++ b/src/hoodini/extra_tools/emapper.py
@@ -122,7 +122,8 @@ def run_emapper(all_prots: pl.DataFrame, output: str | Path, num_threads: int = 
 
         # Query eggnog_prots with filtering - only get rows we need
         # Then explode OGs in DuckDB which is more memory efficient
-        prots = con.execute(f"""
+        prots = con.execute(
+            f"""
             WITH filtered_prots AS (
                 SELECT name, ogs
                 FROM read_parquet('{eggnog_prots_path}')
@@ -140,7 +141,8 @@ def run_emapper(all_prots: pl.DataFrame, output: str | Path, num_threads: int = 
                 split_part(og_level, '@', 2) as level
             FROM exploded
             WHERE og_level != '' AND og_level LIKE '%@%'
-        """).pl()
+        """
+        ).pl()
 
         con.close()
 
@@ -170,10 +172,12 @@ def run_emapper(all_prots: pl.DataFrame, output: str | Path, num_threads: int = 
     try:
         con_og = duckdb.connect(":memory:")
         con_og.execute('SET memory_limit = "4GB"')
-        og = con_og.execute(f"""
+        og = con_og.execute(
+            f"""
             SELECT *, CAST(level AS VARCHAR) as level
             FROM read_parquet('{eggnog_og_path}')
-        """).pl()
+        """
+        ).pl()
         con_og.close()
     except Exception as e:
         warn(f"DuckDB failed for eggnog_og, falling back to Polars: {e}")

--- a/src/hoodini/pipeline/helpers/nuc2asmlen.py
+++ b/src/hoodini/pipeline/helpers/nuc2asmlen.py
@@ -42,7 +42,8 @@ def run_nuc2asmlen(accessions):
         con.executemany("INSERT INTO lookup VALUES (?)", [(a,) for a in query_accessions])
 
         # Query with efficient semi-join
-        matches = con.execute(f"""
+        matches = con.execute(
+            f"""
             SELECT 
                 genbankAccession,
                 refseqAccession,
@@ -51,7 +52,8 @@ def run_nuc2asmlen(accessions):
             FROM read_parquet('{parquet_path}')
             WHERE genbankAccession IN (SELECT nuc_id FROM lookup)
                OR refseqAccession IN (SELECT nuc_id FROM lookup)
-        """).pl()
+        """
+        ).pl()
 
         con.close()
 

--- a/src/hoodini/pipeline/helpers/prefetch_links.py
+++ b/src/hoodini/pipeline/helpers/prefetch_links.py
@@ -120,12 +120,14 @@ def _load_local_assembly_map() -> dict:
 
         con = duckdb.connect(":memory:")
         con.execute('SET memory_limit = "4GB"')
-        df = con.execute(f"""
+        df = con.execute(
+            f"""
             SELECT 
                 CAST(assembly_accession AS VARCHAR) as assembly_accession,
                 CAST(ftp_path AS VARCHAR) as ftp_path
             FROM read_parquet('{str(path)}')
-        """).pl()
+        """
+        ).pl()
         con.close()
 
         _LOCAL_ASM_MAP = dict(

--- a/src/hoodini/pipeline/parse_ipg.py
+++ b/src/hoodini/pipeline/parse_ipg.py
@@ -171,11 +171,13 @@ def _fetch_ipg_data(df: PlDF, cand_mode: str) -> PlDF:
         con.execute("CREATE TEMP TABLE asm_lookup (assembly_id VARCHAR)")
         con.executemany("INSERT INTO asm_lookup VALUES (?)", [(a,) for a in assemblies_stripped])
 
-        ts = con.execute(f"""
+        ts = con.execute(
+            f"""
             SELECT d.*
             FROM read_parquet('{dive_path}') d
             WHERE d.assembly_id IN (SELECT assembly_id FROM asm_lookup)
-        """).pl()
+        """
+        ).pl()
         con.close()
 
         if ts.height > 0:
@@ -199,7 +201,8 @@ def _fetch_ipg_data(df: PlDF, cand_mode: str) -> PlDF:
         con.execute("CREATE TEMP TABLE asm_lookup2 (assembly_accession VARCHAR)")
         con.executemany("INSERT INTO asm_lookup2 VALUES (?)", [(a,) for a in assemblies])
 
-        summary = con.execute(f"""
+        summary = con.execute(
+            f"""
             SELECT 
                 assembly_accession,
                 taxid,
@@ -210,7 +213,8 @@ def _fetch_ipg_data(df: PlDF, cand_mode: str) -> PlDF:
                 "group"
             FROM read_parquet('{summary_path}')
             WHERE assembly_accession IN (SELECT assembly_accession FROM asm_lookup2)
-        """).pl()
+        """
+        ).pl()
         con.close()
 
         if summary.height > 0:
@@ -322,7 +326,8 @@ def _fetch_nucleotide_data(df: PlDF) -> PlDF:
         con.executemany("INSERT INTO lookup VALUES (?)", [(n,) for n in nucs])
 
         # Query parquet with semi-join - DuckDB handles this efficiently
-        result_df = con.execute(f"""
+        result_df = con.execute(
+            f"""
             SELECT nucleotide_id, assembly_id, sequence_length FROM (
                 SELECT genbankAccession as nucleotide_id,
                        assemblyAccession as assembly_id,
@@ -336,7 +341,8 @@ def _fetch_nucleotide_data(df: PlDF) -> PlDF:
                 FROM read_parquet('{contig_path}')
                 WHERE refseqAccession IN (SELECT nuc_id FROM lookup)
             )
-        """).pl()
+        """
+        ).pl()
 
         # Deduplicate
         nuc_map = result_df.unique(subset=["nucleotide_id"], keep="first")
@@ -374,7 +380,8 @@ def _fetch_nucleotide_data(df: PlDF) -> PlDF:
             con.execute("CREATE TEMP TABLE asm_lookup (assembly_id VARCHAR)")
             con.executemany("INSERT INTO asm_lookup VALUES (?)", [(a,) for a in asm_list])
 
-            asm_meta = con.execute(f"""
+            asm_meta = con.execute(
+                f"""
                 SELECT 
                     assembly_accession as assembly_id,
                     taxid,
@@ -385,7 +392,8 @@ def _fetch_nucleotide_data(df: PlDF) -> PlDF:
                     "group"
                 FROM read_parquet('{summary_path}')
                 WHERE assembly_accession IN (SELECT assembly_id FROM asm_lookup)
-            """).pl()
+            """
+            ).pl()
             con.close()
 
             if asm_meta.height > 0:
@@ -451,14 +459,16 @@ def _fetch_nucleotide_data(df: PlDF) -> PlDF:
                             "INSERT INTO new_asm_lookup VALUES (?)", [(a,) for a in new_asm_list]
                         )
 
-                        summary2 = con.execute(f"""
+                        summary2 = con.execute(
+                            f"""
                             SELECT 
                                 assembly_accession as assembly_id,
                                 taxid,
                                 "group"
                             FROM read_parquet('{summary_path}')
                             WHERE assembly_accession IN (SELECT assembly_id FROM new_asm_lookup)
-                        """).pl()
+                        """
+                        ).pl()
                         con.close()
 
                         if summary2.height > 0:

--- a/src/hoodini/utils/validation.py
+++ b/src/hoodini/utils/validation.py
@@ -601,7 +601,8 @@ def uniprot2ncbi(df: pl.DataFrame) -> pl.DataFrame:
     con.execute("CREATE TEMP TABLE lookup_ids (uniprot_ac VARCHAR)")
     con.executemany("INSERT INTO lookup_ids VALUES (?)", [(uid,) for uid in to_map])
 
-    idmap = con.execute(f"""
+    idmap = con.execute(
+        f"""
         SELECT
             m."UniprotKB-AC",
             CASE
@@ -614,7 +615,8 @@ def uniprot2ncbi(df: pl.DataFrame) -> pl.DataFrame:
         FROM read_parquet('{str(idmap_path)}') m
         SEMI JOIN lookup_ids l ON m."UniprotKB-AC" = l.uniprot_ac
         WHERE mapped_id IS NOT NULL
-        """).pl()
+        """
+    ).pl()
 
     con.close()
 


### PR DESCRIPTION
- Issue running `diamond` bioconda build on osx-arm64 is fixed as of v2.1.22:
  - Problem: https://github.com/bbuchfink/diamond/issues/930
  - Bioconda merge: https://github.com/bioconda/bioconda-recipes/pull/62463
- `pyhmmer` needs to be pinned to `<0.12` as of https://github.com/pentamorfico/CRISPRCasTyper/commit/cfc74829c57bdfcfb5640980de46a108d2abd0c4 to stop clash between pypi and conda dependencies.
- `uniprot-id-mapper` was missing.